### PR TITLE
1.50.0-preview0

### DIFF
--- a/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
+++ b/iothub/device/src/Common/Api/ClientApiVersionHelper.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Client
     internal class ClientApiVersionHelper
     {
         internal const string ApiVersionQueryPrefix = "api-version=";
-        internal const string ApiVersionLatest = "2018-06-30";
+        internal const string ApiVersionLatest = "2020-05-31-preview";
 
         public const string ApiVersionString = ApiVersionLatest;
         public const string ApiVersionQueryString = ApiVersionQueryPrefix + ApiVersionString;

--- a/iothub/device/src/IotHubConnectionString.cs
+++ b/iothub/device/src/IotHubConnectionString.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Devices.Client
             IotHubName = builder.IotHubName;
             DeviceId = builder.DeviceId;
             ModuleId = builder.ModuleId;
+            ModelId = builder.ModelId;
 
             HttpsEndpoint = new UriBuilder(Uri.UriSchemeHttps, HostName).Uri;
 
@@ -79,5 +80,7 @@ namespace Microsoft.Azure.Devices.Client
         public string SharedAccessKey { get; private set; }
 
         public string SharedAccessSignature { get; private set; }
+
+        public string ModelId { get; private set; }
     }
 }

--- a/iothub/device/src/IotHubConnectionStringBuilder.cs
+++ b/iothub/device/src/IotHubConnectionStringBuilder.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Devices.Client
         private const string SharedAccessKeyPropertyName = "SharedAccessKey";
         private const string SharedAccessSignaturePropertyName = "SharedAccessSignature";
         private const string GatewayHostNamePropertyName = "GatewayHostName";
+        private const string ModelIdPropertyName = "ModelId";
         private const RegexOptions regexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
         private static readonly TimeSpan regexTimeoutMilliseconds = TimeSpan.FromMilliseconds(500);
         private const string X509CertPropertyName = "X509Cert";
@@ -163,6 +164,11 @@ namespace Microsoft.Azure.Devices.Client
         public string GatewayHostName { get; internal set; }
 
         /// <summary>
+        /// Gets the optional name of the ModelId to use 
+        /// </summary>
+        public string ModelId { get; internal set; }
+
+        /// <summary>
         /// Gets the shared access signature used to connect to the IoT Hub service.
         /// </summary>
         public string SharedAccessSignature { get; internal set; }
@@ -196,6 +202,7 @@ namespace Microsoft.Azure.Devices.Client
             stringBuilder.AppendKeyValuePairIfNotEmpty(SharedAccessSignaturePropertyName, SharedAccessSignature);
             stringBuilder.AppendKeyValuePairIfNotEmpty(X509CertPropertyName, UsingX509Cert);
             stringBuilder.AppendKeyValuePairIfNotEmpty(GatewayHostNamePropertyName, GatewayHostName);
+            stringBuilder.AppendKeyValuePairIfNotEmpty(ModelIdPropertyName, ModelId);
             if (stringBuilder.Length > 0)
             {
                 stringBuilder.Remove(stringBuilder.Length - 1, 1);
@@ -216,7 +223,7 @@ namespace Microsoft.Azure.Devices.Client
             SharedAccessSignature = GetConnectionStringOptionalValue(map, SharedAccessSignaturePropertyName);
             UsingX509Cert = GetConnectionStringOptionalValueOrDefault<bool>(map, X509CertPropertyName, GetX509, true);
             GatewayHostName = GetConnectionStringOptionalValue(map, GatewayHostNamePropertyName);
-
+            ModelId = GetConnectionStringOptionalValue(map, ModelIdPropertyName);
             Validate();
         }
 

--- a/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
+++ b/iothub/device/src/Microsoft.Azure.Devices.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.25.0</Version>
+    <Version>1.50.0-preview1</Version>
     <Title>Microsoft Azure IoT Device Client SDK</Title>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
         private int InboundBacklogSize => this.deviceBoundOneWayProcessor.BacklogSize + this.deviceBoundTwoWayProcessor.BacklogSize;
 
         private ProductInfo productInfo;
+        private string modelId;
 
         private ushort _packetId = 0;
         private SpinLock _packetIdLock = new SpinLock();
@@ -91,7 +92,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
             MqttTransportSettings mqttTransportSettings,
             IWillMessage willMessage,
             IMqttIotHubEventHandler mqttIotHubEventHandler,
-            ProductInfo productInfo)
+            ProductInfo productInfo,
+            string modelId = "")
         {
             Contract.Requires(deviceId != null);
             Contract.Requires(iotHubHostName != null);
@@ -102,6 +104,7 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
 
             this.deviceId = deviceId;
             this.moduleId = moduleId;
+            this.modelId = modelId;
             this.iotHubHostName = iotHubHostName;
             this.passwordProvider = passwordProvider;
             this.mqttTransportSettings = mqttTransportSettings;
@@ -292,7 +295,9 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     ClientId = id,
                     HasUsername = true,
-                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}",
+                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}" +
+                                $"&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}" +
+                                $"&digital-twin-model-id={this.modelId}",
                     HasPassword = !string.IsNullOrEmpty(password),
                     Password = password,
                     KeepAliveInSeconds = this.mqttTransportSettings.KeepAliveInSeconds,

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs
@@ -295,15 +295,18 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 {
                     ClientId = id,
                     HasUsername = true,
-                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}" +
-                                $"&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}" +
-                                $"&digital-twin-model-id={this.modelId}",
+                    Username = $"{this.iotHubHostName}/{id}/?api-version={ClientApiVersionHelper.ApiVersionString}&DeviceClientType={Uri.EscapeDataString(this.productInfo.ToString())}",
                     HasPassword = !string.IsNullOrEmpty(password),
                     Password = password,
                     KeepAliveInSeconds = this.mqttTransportSettings.KeepAliveInSeconds,
                     CleanSession = this.mqttTransportSettings.CleanSession,
                     HasWill = this.mqttTransportSettings.HasWill
                 };
+                if (!String.IsNullOrEmpty(this.modelId))
+                {
+                    connectPacket.Username += $"&digital-twin-model-id={this.modelId}";
+                }
+
                 if (connectPacket.HasWill)
                 {
                     Message message = this.willMessage.Message;

--- a/iothub/device/src/Transport/Mqtt/MqttIotHubAdapterFactory.cs
+++ b/iothub/device/src/Transport/Mqtt/MqttIotHubAdapterFactory.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.Devices.Client.Transport.Mqtt
                 mqttTransportSettings,
                 willMessage,
                 mqttIotHubEventHandler,
-                productInfo);
+                productInfo,
+                iotHubConnectionString.ModelId);
         }
     }
 }

--- a/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
+++ b/iothub/device/tests/ConnectionString/DeviceClientConnectionStringTests.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsNotNull(iotHubConnectionStringBuilder.SharedAccessKeyName);
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessSignature);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithSharedAccessPolicyKey);
+            Assert.IsNull(iotHubConnectionStringBuilder.ModelId);
 
             connectionString = "HostName=acme.azure-devices.net;GatewayHostName=test;SharedAccessKeyName=AllAccessKey;DeviceId=device1;SharedAccessKey=dGVzdFN0cmluZzE=";
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
@@ -247,6 +248,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsNotNull(iotHubConnectionStringBuilder.SharedAccessKeyName);
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessSignature);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithSharedAccessPolicyKey);
+            Assert.IsNull(iotHubConnectionStringBuilder.ModelId);
 
             connectionString = "HostName=acme.azure-devices.net;CredentialType=SharedAccessSignature;DeviceId=device1;SharedAccessSignature=SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey";
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
@@ -257,6 +259,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessKey);
             Assert.IsNotNull(iotHubConnectionStringBuilder.SharedAccessSignature);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithToken);
+            Assert.IsNull(iotHubConnectionStringBuilder.ModelId);
 
             connectionString = "HostName=acme.azure-devices.net;CredentialScope=Device;DeviceId=device1;SharedAccessKey=dGVzdFN0cmluZzE=";
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
@@ -268,6 +271,22 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessKeyName);
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessSignature);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
+            Assert.IsNull(iotHubConnectionStringBuilder.ModelId);
+
+            connectionString = "HostName=acme.azure-devices.net;CredentialScope=Device;DeviceId=device1;SharedAccessKey=dGVzdFN0cmluZzE=;ModelId=dtmi:com:example:model;1";
+            iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.HostName);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.DeviceId);
+            Assert.IsNull(iotHubConnectionStringBuilder.GatewayHostName);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.AuthenticationMethod);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.SharedAccessKey);
+            Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessKeyName);
+            Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessSignature);
+            Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.ModelId);
+            
+
+
 
             connectionString = "HostName=acme.azure-devices.net;CredentialScope=Device;DeviceId=device1;SharedAccessSignature=SharedAccessSignature sr=dh%3a%2f%2facme.azure-devices.net&sig=dGVzdFN0cmluZzU=&se=87824124985&skn=AllAccessKey";
             iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
@@ -279,6 +298,7 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.IsNull(iotHubConnectionStringBuilder.SharedAccessKeyName);
             Assert.IsNotNull(iotHubConnectionStringBuilder.SharedAccessSignature);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithToken);
+            Assert.IsNull(iotHubConnectionStringBuilder.ModelId);
 
             try
             {
@@ -360,6 +380,26 @@ namespace Microsoft.Azure.Devices.Client.Test.ConnectionString
             Assert.AreEqual(hostName, iotHubConnectionStringBuilder.HostName);
             Assert.IsTrue(iotHubConnectionStringBuilder.AuthenticationMethod is DeviceAuthenticationWithRegistrySymmetricKey);
             Assert.IsNull(iotHubConnectionStringBuilder.GatewayHostName);
+        }
+
+        [TestMethod]
+        public void ParseConnectionStringWithModelId()
+        {
+            var connectionString = "HostName=acme.azure-devices.net;CredentialScope=Device;DeviceId=device1;SharedAccessKey=dGVzdFN0cmluZzE=;ModelId=dtmi:com:example:model;1";
+            var iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.ModelId);
+            Assert.AreEqual("dtmi:com:example:model;1", iotHubConnectionStringBuilder.ModelId);
+        }
+
+        [TestMethod]
+        public void ParseConnectionStringWithModelIdNotAtTheEnd()
+        {
+            var connectionString = "HostName=acme.azure-devices.net;DeviceId=device1;ModelId=dtmi:com:example:model;1;SharedAccessKey=dGVzdFN0cmluZzE=";
+            var iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
+            Assert.IsNotNull(iotHubConnectionStringBuilder.ModelId);
+            Assert.AreEqual("dtmi:com:example:model;1", iotHubConnectionStringBuilder.ModelId);
+            Assert.AreEqual("device1", iotHubConnectionStringBuilder.DeviceId);
+            Assert.AreEqual("dGVzdFN0cmluZzE=", iotHubConnectionStringBuilder.SharedAccessKey);
         }
     }
 }


### PR DESCRIPTION
Adds ModelId support. 

Parsing from connection string (ModelId) and adds the digital-twin-model-id to the UserName parameter in the Connect packet.

Updates api version to 2020-05-31-preview

